### PR TITLE
Update for ES 0.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch</groupId>
     <artifactId>redis-river</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <packaging>jar</packaging>
 
     <properties>
-        <elasticsearch.version>0.17.7</elasticsearch.version>
+        <elasticsearch.version>0.19.1</elasticsearch.version>
     </properties>
     
     <repositories>

--- a/src/main/assemblies/esplugin.xml
+++ b/src/main/assemblies/esplugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <assembly>
-	<id>bin</id>
+	<id>plugin</id>
 	<formats>
 		<format>zip</format>
 	</formats>

--- a/src/main/java/org/elasticsearch/plugin/river/redis/RedisRiverPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/river/redis/RedisRiverPlugin.java
@@ -1,7 +1,6 @@
 package org.elasticsearch.plugin.river.redis;
 
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.plugins.AbstractPlugin;
 import org.elasticsearch.river.RiversModule;
 import org.elasticsearch.river.redis.RedisRiverModule;
@@ -22,9 +21,7 @@ public class RedisRiverPlugin extends AbstractPlugin {
 		return "Redis River Plugin";
 	}
 	
-	@Override public void processModule(Module module){
-		if(module instanceof RiversModule){
-			((RiversModule) module).registerRiver("redis", RedisRiverModule.class);
-		}
+	public void onModule(RiversModule module){
+		module.registerRiver("redis", RedisRiverModule.class);
 	}
 }

--- a/src/main/java/org/elasticsearch/river/redis/RedisRiver.java
+++ b/src/main/java/org/elasticsearch/river/redis/RedisRiver.java
@@ -5,10 +5,10 @@ package org.elasticsearch.river.redis;
 */
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
-import org.elasticsearch.client.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;


### PR DESCRIPTION
Updates `RedisRiverPlugin` for new API and switches `org.elasticsearch.client.action.bulk.BulkRequestBuilder` to `org.elasticsearch.action.bulk.BulkRequestBuilder`
